### PR TITLE
fix: Interface element splitting uses a semicolon.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,17 @@ module.exports = {
     // NOTE: typescript-eslint/naming-conventionで対応
     camelcase: 'off',
 
+    '@typescript-eslint/member-delimiter-style': ['error', {
+      'multiline': {
+        'delimiter': 'semi',
+        "requireLast": true
+      },
+      'singleline': {
+        'delimiter': 'semi',
+        'requireLast': true
+      },
+    }],
+
     '@typescript-eslint/naming-convention': ['error',
       { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
       { selector: 'function', format: ['camelCase'] },

--- a/index.js
+++ b/index.js
@@ -24,13 +24,13 @@ module.exports = {
     camelcase: 'off',
 
     '@typescript-eslint/member-delimiter-style': ['error', {
-      'multiline': {
-        'delimiter': 'semi',
-        "requireLast": true
+      multiline: {
+        delimiter: 'semi',
+        requireLast: true,
       },
-      'singleline': {
-        'delimiter': 'semi',
-        'requireLast': true
+      singleline: {
+        delimiter: 'semi',
+        requireLast: true,
       },
     }],
 

--- a/test/fixtures/interfaceSemi.ts
+++ b/test/fixtures/interfaceSemi.ts
@@ -1,0 +1,7 @@
+interface semi {
+  colon: string;
+}
+
+interface nosemi {
+  colon: string
+}

--- a/test/lint.test.js
+++ b/test/lint.test.js
@@ -60,6 +60,11 @@ describe('test', () => {
     expect(result.filter((r) => r === '@typescript-eslint/naming-convention').length).toBe(1);
   });
 
+  test('interfacesSemicolon', () => {
+    const result = linter('test/fixtures/interfaceSemi.ts');
+    expect(result.filter((r) => r === '@typescript-eslint/member-delimiter-style').length).toBe(1);
+  });
+
   test('noUnusedVars', () => {
     const result = linter('test/fixtures/noUnusedVars.ts');
     expect(result.filter((r) => r === '@typescript-eslint/no-unused-vars').length).toBe(1);


### PR DESCRIPTION
I'll follow the `TypeScript Deep Dive` 's notation.
https://basarat.gitbook.io/typescript/type-system/interfaces